### PR TITLE
Custom renderer + exit code

### DIFF
--- a/index.js
+++ b/index.js
@@ -48,12 +48,14 @@ async function testreport(mode, argv, renderer = undefined)
         fs.mkdirSync(results_dir);
     }
 
+    let results = [];
     for( let doc of docs )
     {
         let engine = doc.engine;
         for( let stepFn of doc.steps )
         {
-            await stepFn(engine, sl);
+            let result = await stepFn(engine, sl);
+            results.push(result);
         }
         if( mode == "report")
         {
@@ -65,7 +67,11 @@ async function testreport(mode, argv, renderer = undefined)
     
     // Close spawned processes
     await op.tearDown();
-    process.exit()
+
+    let exitCode = 0;
+    if(results.filter(result => result.status == false).length > 0) exitCode = 1;
+
+    process.exit(exitCode);
 }
 
 module.exports = testreport;

--- a/index.js
+++ b/index.js
@@ -28,10 +28,10 @@ const Steps     = require('./lib/steps');
 
 })();
 
-async function testreport(mode, argv)
+async function testreport(mode, argv, renderer = undefined)
 {
     // documents and associated steps; connector to infrastructure provider
-    let stepper = new Steps();
+    let stepper = new Steps(renderer);
 
     let {docs, conn, provider} = await stepper.read(argv.stepfile);
     let cwd = provider === 'local' ? path.join(process.cwd(), path.dirname(argv.stepfile), 'docable_results') : '.';
@@ -47,7 +47,7 @@ async function testreport(mode, argv)
     if (!fs.existsSync(results_dir)) {
         fs.mkdirSync(results_dir);
     }
-    
+
     for( let doc of docs )
     {
         let engine = doc.engine;

--- a/lib/parse.js
+++ b/lib/parse.js
@@ -2,66 +2,15 @@ const cheerio = require('cheerio');
 const marked = require('marked');
 const fs = require('fs');
 const chalk = require('chalk');
+const path = require('path');
 
 class Parse
 {
-    async markdown2HTML( file )
+    async markdown2HTML( file, renderer = undefined )
     {
-        let markdown = fs.readFileSync( file ).toString();
-
-        // Set options
-        marked.setOptions({
-            renderer: new marked.Renderer(),
-            highlight: function(code) {
-                return require('highlight.js').highlightAuto(code).value;
-            },            
-            pedantic: false,
-            gfm: true,
-            tables: true,
-            breaks: false,
-            sanitize: false,
-            smartLists: true,
-            smartypants: false,
-            xhtml: false
-        });
-
         // Simplifying assumption: Never a duplicate code block in same tutorial.
         let metadata = {};
-        let tokens = marked.lexer(markdown);
-
-        let parsedTokens = [];
-        let index = 1;
-        for( let t of tokens )
-        {
-            if( t.type == "code" && t.lang )
-            {
-                let data = t.lang.indexOf("|") >= 0 ? t.lang.split('|') : [];
-                let metaObj = {}
-                let lang = data.length > 0 ? data[0] : "";
-                metaObj.codeIndex = index++;
-
-                for( let propertyFragment of data )
-                {
-                    if( propertyFragment.indexOf("=") >= 0)
-                    {
-                        let property = propertyFragment.split("=")[0].trim();
-                        let val = propertyFragment.split("=")[1].trim();
-                        metaObj[property] = val;
-                    }
-                    else{
-                        metaObj[propertyFragment] = propertyFragment;
-                    }
-                    metadata[t.text] = metaObj;
-                }
-                // Remove metadata
-                t.lang = lang;
-            }
-            parsedTokens.push(t);
-        }
-        parsedTokens.links = tokens.links;
-
-        // Parse tokens
-        let html = await marked.parser(parsedTokens);
+        let html = await this.render(file, metadata, renderer);
 
         console.log(chalk`{bold Translated markdown into html:}`)
         console.log(chalk`{gray ${html}}`);
@@ -95,6 +44,72 @@ class Parse
         // console.log( metadata );
 
         return {engine: $, metadata: metadata };
+    }
+
+    async render(file, metadata, renderer) {
+        let html;
+        if(renderer) {
+            html = renderer.parser(file);
+        } 
+        
+        // if renderer is not provided, use marked.parser() by default
+        else {
+            // Set options
+            marked.setOptions({
+                renderer: new marked.Renderer(),
+                highlight: function(code) {
+                    return require('highlight.js').highlightAuto(code).value;
+                },            
+                pedantic: false,
+                gfm: true,
+                tables: true,
+                breaks: false,
+                sanitize: false,
+                smartLists: true,
+                smartypants: false,
+                xhtml: false
+            });
+            let parsedTokens = this.tokenize(file, metadata);
+            html = await marked.parser(parsedTokens);
+        }
+        return html;
+    }
+
+    // Parse tokens
+    tokenize(file, metadata) {
+        let markdown = fs.readFileSync( file ).toString();
+        let tokens = marked.lexer(markdown);
+        let parsedTokens = [];
+        let index = 1;
+        for( let t of tokens )
+        {
+            if( t.type == "code" && t.lang )
+            {
+                let data = t.lang.indexOf("|") >= 0 ? t.lang.split('|') : [];
+                let metaObj = {};
+                let lang = data.length > 0 ? data[0] : "";
+                metaObj.codeIndex = index++;
+
+                for( let propertyFragment of data )
+                {
+                    if( propertyFragment.indexOf("=") >= 0)
+                    {
+                        let property = propertyFragment.split("=")[0].trim();
+                        let val = propertyFragment.split("=")[1].trim();
+                        metaObj[property] = val;
+                    }
+                    else {
+                        metaObj[propertyFragment] = propertyFragment;
+                    }
+                    metadata[t.text] = metaObj;
+                }
+                // Remove metadata
+                t.lang = lang;
+            }
+            parsedTokens.push(t);
+        }
+        parsedTokens.links = tokens.links;
+        return parsedTokens;
     }
 }
 

--- a/lib/steps.js
+++ b/lib/steps.js
@@ -147,6 +147,7 @@ class Steps {
             await this._setPassing(selector);
         else
             await this._setFailing(selector, response.error );
+        return results;
     }
 
     async _setPassing(selector) 

--- a/lib/steps.js
+++ b/lib/steps.js
@@ -8,8 +8,9 @@ const Parse     = require('./parse');
 
 class Steps {
  
-    constructor() 
+    constructor(renderer) 
     {
+        this.renderer = renderer;
     }
 
     async read(stepFile)
@@ -38,7 +39,7 @@ class Steps {
             {
                 console.log(cwd, topLevelProperty)
                 let md = path.join(cwd, topLevelProperty);
-                let {engine, metadata} = await parser.markdown2HTML(md);
+                let {engine, metadata} = await parser.markdown2HTML(md, this.renderer);
 
                 if( doc[topLevelProperty].steps )
                 {
@@ -150,18 +151,15 @@ class Steps {
 
     async _setPassing(selector) 
     {
-        const content = await selector().text();
-        await selector().text('✓ ' + content);
-        await selector().css('background-color', '#BDFCC9');
+        selector().prepend('<span>✓ </span>');
+        selector().css('background-color', '#BDFCC9');
     }
 
     async _setFailing(selector, error)
     {
-        const content = await selector().text();
-        await selector().text('𐄂 ' + content + "\n\n" + error);
-        await selector().css('background-color', 'LightCoral');
+        selector().prepend('<span>𐄂 </span>');
+        selector().css('background-color', 'LightCoral');
     }
 }
-
 
 module.exports = Steps;


### PR DESCRIPTION
- Adding support for custom renderer (when calling `testreport()`)
- Setting exit code to 1 if anything fails