### PR TITLE
adding `user: <user>` for steps

### DIFF
--- a/examples/unix-service/steps.yml
+++ b/examples/unix-service/steps.yml
@@ -18,5 +18,5 @@ unix-service.md:
     - selectAndServe: "start it:"
     - selectAndExpect: "another terminal:"
 
-unix-service-inline.md:
-  steps: inline
+# unix-service-inline.md:
+#   steps: inline

--- a/examples/unix-service/steps.yml
+++ b/examples/unix-service/steps.yml
@@ -10,8 +10,11 @@ unix-service.md:
     # - selectAndServe: "start it:"
     # - selectAndExpect: "another terminal:"
     - selectAsFile: "create a file called => /etc/systemd/system/rot13.service"
+      become: root
     - selectAndRun: "start the service:"
+      become: root
     - selectAndRun: "start on boot:"
+      become: root
     - selectAndServe: "start it:"
     - selectAndExpect: "another terminal:"
 

--- a/examples/unix-service/unix-service.md
+++ b/examples/unix-service/unix-service.md
@@ -39,12 +39,13 @@ Let’s create a file called `/etc/systemd/system/rot13.service`:
 Description=ROT13 demo service
 After=network.target
 StartLimitIntervalSec=0
+
 [Service]
 Type=simple
 Restart=always
 RestartSec=1
-User=centos
-ExecStart=/usr/bin/env php ~/server.php
+User=root
+ExecStart=/bin/sh -c "php $HOME/server.php"
 
 [Install]
 WantedBy=multi-user.target

--- a/lib/operators.js
+++ b/lib/operators.js
@@ -1,5 +1,7 @@
 const chalk = require('chalk');
 const path  = require('path');
+const os    = require('os');
+const hostUsername = os.userInfo().username;
 
 class Operators {
     constructor(connector, cwd)
@@ -14,13 +16,15 @@ class Operators {
     }
 
     // Place content as file
-    async file(content, location)
+    async file(content, location, user)
     {
         console.log(chalk`{blue placing contents in file:} {rgb(173,216,230) ${location}}\n${content.substring(0,50)}...`);
         let output;
         if(location.includes('/'))
+            // output = await this.connector.exec( `${this.sudoCMD(user)} tee ${location.trim()} << 'END'\n ${content}\nEND\n`);
             output = await this.connector.exec( `cat << 'END' > ${location.trim()}\n${content}\nEND\n`);
         else
+            // output = await this.connector.exec( `${this.sudoCMD(user)} tee ${path.join(this.cwd, location.trim())} << 'END'\n ${content}\nEND\n`);
             output = await this.connector.exec( `cat << 'END' > ${path.join(this.cwd, location.trim())}\n${content}\nEND\n`);
 
         if (output.exitCode != 0) {
@@ -30,10 +34,10 @@ class Operators {
     }
 
     // Long running command...
-    async running(cmd)
+    async running(cmd, user)
     {
         console.log(chalk`{rgb(255,136,0) running background command...}\n${cmd}`);
-        let results = await this.connector.spawn(`${cmd}`, {cwd: this.cwd});
+        let results = await this.connector.spawn(`${this.sudoCMD(user)} ${cmd}`, {cwd: this.cwd});
         if( results.pid )
         {
             console.log( `Spawned pid: ${results.pid}`);
@@ -44,10 +48,10 @@ class Operators {
     }
 
     // Simple command
-    async run(cmd)
+    async run(cmd, user)
     {
         console.log(chalk`{green running...}\n${cmd}`);
-        let output = await this.connector.exec(`cd ${this.cwd} && ` + cmd);
+        let output = await this.connector.exec(`cd ${this.cwd} && ${this.sudoCMD(user)} ` + cmd);
         return output;
     }
 
@@ -61,6 +65,13 @@ class Operators {
                 await this.connector.exec(`kill -9 ${pid}`);
             }
         }
+    }
+
+    sudoCMD(user) {
+        if (user)
+            return `sudo -u ${user}`;
+        else
+            return '';
     }
 }
 

--- a/lib/operators.js
+++ b/lib/operators.js
@@ -21,16 +21,14 @@ class Operators {
         console.log(chalk`{blue placing contents in file:} {rgb(173,216,230) ${location}}\n${content.substring(0,50)}...`);
         let output;
         if(location.includes('/'))
-            // output = await this.connector.exec( `${this.sudoCMD(user)} tee ${location.trim()} << 'END'\n ${content}\nEND\n`);
-            output = await this.connector.exec( `cat << 'END' > ${location.trim()}\n${content}\nEND\n`);
+            output = await this.connector.exec( `${this.sudoCMD(user)} tee ${location.trim()} << 'END'\n${content}\nEND\n`);
         else
-            // output = await this.connector.exec( `${this.sudoCMD(user)} tee ${path.join(this.cwd, location.trim())} << 'END'\n ${content}\nEND\n`);
-            output = await this.connector.exec( `cat << 'END' > ${path.join(this.cwd, location.trim())}\n${content}\nEND\n`);
+            output = await this.connector.exec( `${this.sudoCMD(user)} tee ${path.join(this.cwd, location.trim())} << 'END'\n${content}\nEND\n`);
 
         if (output.exitCode != 0) {
             throw (output.stderr);
         }
-        console.log(JSON.stringify(output));
+        return output;
     }
 
     // Long running command...

--- a/lib/select.js
+++ b/lib/select.js
@@ -21,12 +21,12 @@ class Select {
         return $(`p:contains("${searchText.trim()}")`).next();
     }
 
-    async selectAsFile(content, destination)
+    async selectAsFile(content, destination, user)
     {
         return new Promise(async (resolve, reject) => 
         {
             try {
-                await this.op.file( content, destination);
+                await this.op.file( content, destination, user);
                 resolve({status: true});
             } catch(err) {
                 console.error(err);
@@ -36,14 +36,14 @@ class Select {
 
     }
 
-    async selectAndExpect(content)
+    async selectAndExpect(content, user)
     {
         return new Promise(async(resolve, reject) => 
         {
             let {cmd, expect} = tr.commandExpects(content);
             cmd = tr.trimPrompt(cmd);
 
-            let serverResponse = await this.op.run(cmd);
+            let serverResponse = await this.op.run(cmd, user);
 
             if(serverResponse.stdout.trimRight() != expect )
             {
@@ -57,7 +57,7 @@ class Select {
         });
     }
 
-    async selectAndRun(content)
+    async selectAndRun(content, user)
     {
         return new Promise(async(resolve, reject) => 
         {
@@ -65,7 +65,7 @@ class Select {
 
             // server...
             try {
-                let output = await this.op.run(cmd);
+                let output = await this.op.run(cmd, user);
                 resolve({status: output.exitCode == 0, error: output.stderr});
             } catch(err) {
                 resolve({error: err, status: false});
@@ -73,7 +73,7 @@ class Select {
         });
     }
 
-    async selectAndServe(content)
+    async selectAndServe(content, user)
     {
         return new Promise(async(resolve, reject) => 
         {
@@ -81,7 +81,7 @@ class Select {
 
             // server...
             try {
-                await this.op.running(cmd);
+                await this.op.running(cmd, user);
                 resolve({status: true});
             } catch(err) {
                 console.error(err);

--- a/lib/select.js
+++ b/lib/select.js
@@ -23,7 +23,6 @@ class Select {
     splitLines(content)
     {
         let lines = content.split(/\r?\n/);
-        console.log(lines);
         return lines;
     }
 
@@ -32,10 +31,11 @@ class Select {
         return new Promise(async (resolve, reject) => 
         {
             try {
-                await this.op.file( content, destination, user);
-                resolve({status: true});
+                let output = await this.op.file( content, destination, user);
+                if(output.stderr) console.log(chalk`{red error: ${output.stderr}}`)
+                resolve({status: output.exitCode == 0, error: output.stderr});
             } catch(err) {
-                console.error(err);
+                console.log(chalk`{red error: ${err}}`)
                 resolve({error: err, status: false});
             }
         });
@@ -63,6 +63,7 @@ class Select {
             }
             else{
                 console.log(chalk`{red expected ${serverResponse.stdout} == ${expect}}`);
+                console.log(chalk`{red error: ${serverResponse.stderr}}`)
                 resolve({error: serverResponse.stdout + serverResponse.stderr, status: false});
             }
         });
@@ -77,8 +78,10 @@ class Select {
             // server...
             try {
                 let output = await this.op.run(cmd, user);
+                if(output.stderr) console.log(chalk`{red error: ${output.stderr}}`)
                 resolve({status: output.exitCode == 0, error: output.stderr});
             } catch(err) {
+                console.log(chalk`{red error: ${err}}`)
                 resolve({error: err, status: false});
             }
         });

--- a/lib/steps.js
+++ b/lib/steps.js
@@ -139,6 +139,7 @@ class Steps {
             if( step instanceof Object )
             {
                 let key = Object.keys(step)[0];
+                let user = step[Object.keys(step)[1]];
                 switch( key )
                 {
                     case "selectAsFile":
@@ -146,25 +147,25 @@ class Steps {
                         let searchText = step[key].split("=>")[0];
                         let file = step[key].split("=>")[1];
 
-                        steps.push( async ($,sl) => this._setResults(() => sl.asContainsNextElement($, searchText), await sl.selectAsFile( sl.asContainsNext($, searchText), file )));
+                        steps.push( async ($,sl) => this._setResults(() => sl.asContainsNextElement($, searchText), await sl.selectAsFile( sl.asContainsNext($, searchText), file, user )));
                         break;
                     }
                     case "selectAndServe":
                     {
                         let searchText = step[key];
-                        steps.push( async ($,sl) => this._setResults(() => sl.asContainsNextElement($, searchText), await sl.selectAndServe( sl.asContainsNext($, searchText) )));
+                        steps.push( async ($,sl) => this._setResults(() => sl.asContainsNextElement($, searchText), await sl.selectAndServe( sl.asContainsNext($, searchText), user )));
                         break;
                     }
                     case "selectAndExpect":
                     {
                         let searchText = step[key];
-                        steps.push( async ($,sl) => this._setResults(() => sl.asContainsNextElement($, searchText), await sl.selectAndExpect( sl.asContainsNext($, searchText))) );
+                        steps.push( async ($,sl) => this._setResults(() => sl.asContainsNextElement($, searchText), await sl.selectAndExpect( sl.asContainsNext($, searchText), user )) );
                         break;
                     }
                     case "selectAndRun":
                     {
                         let searchText = step[key];
-                        steps.push( async ($,sl) => this._setResults(() => sl.asContainsNextElement($, searchText), await sl.selectAndRun( sl.asContainsNext($, searchText))) );
+                        steps.push( async ($,sl) => this._setResults(() => sl.asContainsNextElement($, searchText), await sl.selectAndRun( sl.asContainsNext($, searchText), user )) );
                         break;
                     }
                     default:


### PR DESCRIPTION
now can specify the user for each code block. For example:
``` yaml
unix-service.md:
  steps:
    - selectAsFile: ROT13 transformation => server.php
    - selectAsFile: "create a file called => /etc/systemd/system/rot13.service"
      become: root
    - selectAndRun: "start the service:"
      become: root
    - selectAndRun: "start on boot:"
      become: root
```
+ also printing error messages in cli